### PR TITLE
fix benefits routing issue

### DIFF
--- a/src/app/my/benefits/benefits-routing.module.ts
+++ b/src/app/my/benefits/benefits-routing.module.ts
@@ -7,7 +7,7 @@ import {BenefitIctComponent} from './benefit-ict/benefit-ict.component';
 
 const benefitsRoutes: Routes = [
   {
-    path: 'benefits', component: BenefitsComponent, children: [
+    path: '', component: BenefitsComponent, children: [
       {path: '', component: BenefitsOverviewComponent, pathMatch: 'full'},
       {path: 'cash', component: BenefitCashComponent},
       {path: 'ict', component: BenefitIctComponent}

--- a/src/app/my/my-routing.module.ts
+++ b/src/app/my/my-routing.module.ts
@@ -2,11 +2,13 @@ import {Routes, RouterModule} from '@angular/router';
 import {NgModule} from '@angular/core';
 import {DashboardComponent} from './dashboard/dashboard.component';
 import {MyComponent} from './my.component';
+import {BenefitsModule} from './benefits/benefits.module';
 import {AuthGuard} from '../shared/auth-guard';
 
 const myRoutes: Routes = [{
   path: '', component: MyComponent, canActivate: [AuthGuard], children: [
     {path: '', component: DashboardComponent, pathMatch: 'full'},
+    {path: 'benefits', loadChildren: () => BenefitsModule},
   ]
 }];
 

--- a/src/app/my/my.module.ts
+++ b/src/app/my/my.module.ts
@@ -6,7 +6,6 @@ import {DashboardComponent} from './dashboard/dashboard.component';
 import {MyHeaderComponent} from './my-header/my-header.component';
 import {MyComponent} from './my.component';
 import {MyRoutingModule} from './my-routing.module';
-import {BenefitsModule} from './benefits/benefits.module';
 
 @NgModule({
   declarations: [
@@ -17,8 +16,7 @@ import {BenefitsModule} from './benefits/benefits.module';
   imports: [
     CommonModule,
     FormsModule,
-    MyRoutingModule,
-    BenefitsModule
+    MyRoutingModule
   ],
   providers: [
   ]


### PR DESCRIPTION
This should fix the benefits routing issue.

The thing is that you wanted the `BenefitsComponent` to load inside `MyComponent`. But how can he do that if it's not a child of `MyComponent`? So in order to fix that you need to add it to the `children` list like you do when lazy loading. The only thing is, you don't want lazy loading here. But since RC6 (and thus also the release) of the Router, you can just pass down a function that returns a module. This makes switching to lazy loading quite simple as well, just remove the import and use a string literal to point to the module.